### PR TITLE
feat: Added methodSignatures filter

### DIFF
--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -222,6 +222,16 @@ function indexerPostFilter(subscription: TransactionFilter): (t: TransactionResu
         !!t['application-transaction']['application-args'] &&
         t['application-transaction']['application-args'][0] === getMethodSelectorBase64(subscription.methodSignature)
     }
+    if (subscription.methodSignatures) {
+      subscription.methodSignatures.filter(
+        (method) =>
+          !!t['application-transaction'] &&
+          !!t['application-transaction']['application-args'] &&
+          t['application-transaction']['application-args'][0] === getMethodSelectorBase64(method),
+      ).length > 0
+        ? (result &&= true)
+        : (result &&= false)
+    }
     if (subscription.appCallArgumentsMatch) {
       result &&=
         !!t['application-transaction'] &&
@@ -286,6 +296,13 @@ function transactionFilter(
     }
     if (subscription.methodSignature) {
       result &&= !!t.appArgs && Buffer.from(t.appArgs[0] ?? []).toString('base64') === getMethodSelectorBase64(subscription.methodSignature)
+    }
+    if (subscription.methodSignatures) {
+      subscription.methodSignatures.filter(
+        (method) => !!t.appArgs && Buffer.from(t.appArgs[0] ?? []).toString('base64') === getMethodSelectorBase64(method),
+      ).length > 0
+        ? (result &&= true)
+        : (result &&= false)
     }
     if (subscription.appCallArgumentsMatch) {
       result &&= subscription.appCallArgumentsMatch(t.appArgs)

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -121,6 +121,8 @@ export interface TransactionFilter {
   /** Filter to app transactions that have the given ARC-0004 method selector for
    * the given method signature as the first app argument. */
   methodSignature?: string
+  /** Filter to app transactions that match one of the given ARC-0004 method selectors as the first app argument. */
+  methodSignatures?: string[]
   /** Filter to app transactions that meet the given app arguments predicate. */
   appCallArgumentsMatch?: (appCallArguments?: Uint8Array[]) => boolean
 }

--- a/tests/scenarios/filters.spec.ts
+++ b/tests/scenarios/filters.spec.ts
@@ -437,6 +437,29 @@ describe('Subscribing using various filters', () => {
     )
   })
 
+  test('Works for method signatures', async () => {
+    const { testAccount, algod } = localnet.context
+    const app1 = await app({ create: true })
+    const txns = await algokit.sendGroupOfTransactions(
+      {
+        transactions: [
+          app1.app.callAbi({ value: 'test' }, { sender: testAccount, sendParams: { skipSending: true } }),
+          app1.app.optIn.optIn({}, { sender: testAccount, sendParams: { skipSending: true } }),
+        ],
+        signer: testAccount,
+      },
+      algod,
+    )
+
+    await subscribeAndVerifyFilter(
+      {
+        sender: testAccount.addr,
+        methodSignatures: ['opt_in()void'],
+      },
+      extractFromGroupResult(txns, 1),
+    )
+  })
+
   test('Works for app args', async () => {
     const { testAccount, algod } = localnet.context
     const app1 = await app({ create: true })

--- a/tests/scenarios/filters.spec.ts
+++ b/tests/scenarios/filters.spec.ts
@@ -454,7 +454,7 @@ describe('Subscribing using various filters', () => {
     await subscribeAndVerifyFilter(
       {
         sender: testAccount.addr,
-        methodSignatures: ['opt_in()void'],
+        methodSignatures: ['opt_in()void', 'madeUpMethod()void'],
       },
       extractFromGroupResult(txns, 1),
     )


### PR DESCRIPTION
## Proposed Changes

`methodSignatures` is of type`string[]` and will be used to Filter to app transactions that match one of the given ARC-0004 method selectors as the first app argument.

I've found myself needing to filter app transactions that use one of a few different methods and thought it might be helpful for other to have. 

## Related Issue 
#18 

