### PR TITLE
feat: support emitting event generator thunks

### DIFF
--- a/docs/code/classes/index.AlgorandSubscriber.md
+++ b/docs/code/classes/index.AlgorandSubscriber.md
@@ -181,7 +181,7 @@ new AlgorandSubscriber({filters: [{name: 'my-filter', filter: {...}, mapper: (t)
 
 #### Defined in
 
-[subscriber.ts:176](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L176)
+[subscriber.ts:178](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L178)
 
 ___
 
@@ -231,7 +231,7 @@ new AlgorandSubscriber({filters: [{name: 'my-filter', filter: {...}, mapper: (t)
 
 #### Defined in
 
-[subscriber.ts:202](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L202)
+[subscriber.ts:204](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L204)
 
 ___
 
@@ -265,7 +265,7 @@ subscriber.onBeforePoll(async (metadata) => { console.log(metadata.watermark) })
 
 #### Defined in
 
-[subscriber.ts:220](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L220)
+[subscriber.ts:222](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L222)
 
 ___
 
@@ -302,7 +302,7 @@ subscriber.onPoll(async (pollResult) => { console.log(pollResult.subscribedTrans
 
 #### Defined in
 
-[subscriber.ts:241](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L241)
+[subscriber.ts:243](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L243)
 
 ___
 
@@ -350,7 +350,7 @@ An object that contains a promise you can wait for after calling stop
 
 #### Defined in
 
-[subscriber.ts:105](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L105)
+[subscriber.ts:107](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L107)
 
 ___
 
@@ -374,4 +374,4 @@ A promise that can be awaited to ensure the subscriber has finished stopping
 
 #### Defined in
 
-[subscriber.ts:149](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L149)
+[subscriber.ts:151](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L151)

--- a/docs/code/classes/types_async_event_emitter.AsyncEventEmitter.md
+++ b/docs/code/classes/types_async_event_emitter.AsyncEventEmitter.md
@@ -82,7 +82,7 @@ Alias for `removeListener`.
 
 #### Defined in
 
-[types/async-event-emitter.ts:82](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L82)
+[types/async-event-emitter.ts:85](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L85)
 
 ## Methods
 
@@ -131,7 +131,7 @@ The `AsyncEventEmitter` so you can chain registrations
 
 #### Defined in
 
-[types/async-event-emitter.ts:33](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L33)
+[types/async-event-emitter.ts:36](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L36)
 
 ___
 
@@ -156,7 +156,7 @@ The `AsyncEventEmitter` so you can chain registrations
 
 #### Defined in
 
-[types/async-event-emitter.ts:45](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L45)
+[types/async-event-emitter.ts:48](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L48)
 
 ___
 
@@ -181,4 +181,4 @@ The `AsyncEventEmitter` so you can chain registrations
 
 #### Defined in
 
-[types/async-event-emitter.ts:63](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L63)
+[types/async-event-emitter.ts:66](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/async-event-emitter.ts#L66)

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -61,11 +61,13 @@ export class AlgorandSubscriber {
   async pollOnce(): Promise<TransactionSubscriptionResult> {
     const watermark = await this.config.watermarkPersistence.get()
 
-    const currentRound = (await this.algod.status().do())['last-round'] as number
-    await this.eventEmitter.emitAsync('before:poll', {
-      watermark,
-      currentRound,
-    } satisfies BeforePollMetadata)
+    await this.eventEmitter.emitAsync('before:poll', async () => {
+      const currentRound = (await this.algod.status().do())['last-round'] as number
+      return {
+        watermark,
+        currentRound,
+      } satisfies BeforePollMetadata
+    })
 
     const pollResult = await getSubscribedTransactions(
       {

--- a/src/types/async-event-emitter.ts
+++ b/src/types/async-event-emitter.ts
@@ -18,9 +18,12 @@ export class AsyncEventEmitter {
    * @param eventName The name of the event
    * @param event The event payload
    */
-  async emitAsync(eventName: string | symbol, event: unknown): Promise<void> {
-    for (const listener of this.listenerMap[eventName] ?? []) {
-      await listener(event, eventName)
+  async emitAsync(eventName: string | symbol, event: unknown | (() => Promise<unknown>)): Promise<void> {
+    if (this.listenerMap[eventName] && this.listenerMap[eventName].length > 0) {
+      const emittedEvent = typeof event === 'function' ? await event() : event
+      for (const listener of this.listenerMap[eventName]) {
+        await listener(emittedEvent, eventName)
+      }
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "isolatedModules": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
-  "include": ["examples/**/*.ts", "src/**/*.ts", "tests/**/*.ts", "rollup/**/*.ts", "rollup.config.ts"],
+  "include": ["examples/**/*.ts", "src/**/*.ts", "tests/**/*.ts", "rollup/**/*.ts", "rollup.config.ts"]
 }


### PR DESCRIPTION
Interested in your thoughts on this one.

I noticed that the `algod.status` endpoint was always called twice when waiting for the block at the tip, which felt slightly wasteful.
It is called to retrieve the last round, which is used for emitting the `before:poll` event and used inside `getSubscribedTransactions`.

Two ways I thought about solving this:
1. Get the current round once and pass the value when creating the `before:poll` event and pass as a parameter to `getSubscribedTransactions` via `TransactionSubscriptionParams`.

     Pros:
     - Conceptually simpler
    - Ensures current round value is consistent across a single poll
  
    Cons:
    - It's a breaking behaviour change to `getSubscribedTransactions`, if someone is using it directly.
    - Requires fetching the current round prior to calling `getSubscribedTransactions`

1. Support event generator thunks inside `eventEmitter.emitAsync` (this PR).

     Pros:
     - We have a pattern to defer logic to only run when a subscription exists.
     - No breaking changes.

     Cons:
     - If you subscribe to `before:poll`, multiple status calls will be made.
     - It's possible to get different current round values for a single poll (current logic in main has this behaviour as well)

What option do you prefer?