### PR TITLE
fix: align to indexer note handling for algod fetched transactions

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -458,7 +458,7 @@ export function getIndexerTransactionFromAlgodTransaction(
       'genesis-hash': Buffer.from(transaction.genesisHash).toString('base64'),
       'genesis-id': transaction.genesisID,
       group: transaction.group ? Buffer.from(transaction.group).toString('base64') : undefined,
-      note: transaction.note ? Buffer.from(transaction.note).toString('utf-8') : undefined,
+      note: transaction.note ? Buffer.from(transaction.note).toString('base64') : undefined,
       lease: transaction.lease ? Buffer.from(transaction.lease).toString('base64') : undefined,
       'rekey-to': transaction.reKeyTo ? algosdk.encodeAddress(transaction.reKeyTo.publicKey) : undefined,
       'closing-amount': closeAmount,


### PR DESCRIPTION
note fetch via algod (using this library)
<img width="1484" alt="Screenshot 2024-04-18 at 5 09 37 PM" src="https://github.com/algorandfoundation/algokit-subscriber-ts/assets/1495003/824fbad1-254b-4820-bc01-b4142cce1e8e">

note fetched via indexer (directly)
<img width="767" alt="Screenshot 2024-04-18 at 5 09 49 PM" src="https://github.com/algorandfoundation/algokit-subscriber-ts/assets/1495003/a8034237-7a31-4273-b096-6c0741c15ac3">

This PR fixes the above.