### PR TITLE
fix: prevent double status calls when calling pollOnce

### DIFF
--- a/docs/code/classes/index.AlgorandSubscriber.md
+++ b/docs/code/classes/index.AlgorandSubscriber.md
@@ -181,7 +181,7 @@ new AlgorandSubscriber({filters: [{name: 'my-filter', filter: {...}, mapper: (t)
 
 #### Defined in
 
-[subscriber.ts:176](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L176)
+[subscriber.ts:177](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L177)
 
 ___
 
@@ -231,7 +231,7 @@ new AlgorandSubscriber({filters: [{name: 'my-filter', filter: {...}, mapper: (t)
 
 #### Defined in
 
-[subscriber.ts:202](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L202)
+[subscriber.ts:203](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L203)
 
 ___
 
@@ -265,7 +265,7 @@ subscriber.onBeforePoll(async (metadata) => { console.log(metadata.watermark) })
 
 #### Defined in
 
-[subscriber.ts:220](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L220)
+[subscriber.ts:221](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L221)
 
 ___
 
@@ -302,7 +302,7 @@ subscriber.onPoll(async (pollResult) => { console.log(pollResult.subscribedTrans
 
 #### Defined in
 
-[subscriber.ts:241](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L241)
+[subscriber.ts:242](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L242)
 
 ___
 
@@ -350,7 +350,7 @@ An object that contains a promise you can wait for after calling stop
 
 #### Defined in
 
-[subscriber.ts:106](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L106)
+[subscriber.ts:107](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L107)
 
 ___
 
@@ -374,4 +374,4 @@ A promise that can be awaited to ensure the subscriber has finished stopping
 
 #### Defined in
 
-[subscriber.ts:149](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L149)
+[subscriber.ts:150](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/subscriber.ts#L150)

--- a/docs/code/interfaces/types_subscription.AlgorandSubscriberConfig.md
+++ b/docs/code/interfaces/types_subscription.AlgorandSubscriberConfig.md
@@ -55,7 +55,7 @@ The set of filters to subscribe to / emit events for, along with optional data m
 
 #### Defined in
 
-[types/subscription.ts:256](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L256)
+[types/subscription.ts:261](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L261)
 
 ___
 
@@ -67,7 +67,7 @@ The frequency to poll for new blocks in seconds; defaults to 1s
 
 #### Defined in
 
-[types/subscription.ts:258](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L258)
+[types/subscription.ts:263](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L263)
 
 ___
 
@@ -155,7 +155,7 @@ Whether to wait via algod `/status/wait-for-block-after` endpoint when at the ti
 
 #### Defined in
 
-[types/subscription.ts:260](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L260)
+[types/subscription.ts:265](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L265)
 
 ___
 
@@ -175,4 +175,4 @@ its position in the chain
 
 #### Defined in
 
-[types/subscription.ts:263](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L263)
+[types/subscription.ts:268](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L268)

--- a/docs/code/interfaces/types_subscription.SubscriberConfigFilter.md
+++ b/docs/code/interfaces/types_subscription.SubscriberConfigFilter.md
@@ -70,7 +70,7 @@ Note: if you provide multiple filters with the same name then only the mapper of
 
 #### Defined in
 
-[types/subscription.ts:279](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L279)
+[types/subscription.ts:284](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L284)
 
 ___
 

--- a/docs/code/interfaces/types_subscription.TransactionSubscriptionParams.md
+++ b/docs/code/interfaces/types_subscription.TransactionSubscriptionParams.md
@@ -17,6 +17,7 @@ Parameters to control a single subscription pull/poll.
 ### Properties
 
 - [arc28Events](types_subscription.TransactionSubscriptionParams.md#arc28events)
+- [currentRound](types_subscription.TransactionSubscriptionParams.md#currentround)
 - [filters](types_subscription.TransactionSubscriptionParams.md#filters)
 - [maxIndexerRoundsToSync](types_subscription.TransactionSubscriptionParams.md#maxindexerroundstosync)
 - [maxRoundsToSync](types_subscription.TransactionSubscriptionParams.md#maxroundstosync)
@@ -38,6 +39,19 @@ Any ARC-28 event definitions to process from app call logs
 #### Defined in
 
 [types/subscription.ts:133](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L133)
+
+___
+
+### currentRound
+
+• `Optional` **currentRound**: `number`
+
+The current tip of the configured Algorand blockchain.
+If not provided, it will be resolved on demand.
+
+#### Defined in
+
+[types/subscription.ts:255](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L255)
 
 ___
 

--- a/docs/code/modules/types_subscription.md
+++ b/docs/code/modules/types_subscription.md
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[types/subscription.ts:282](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L282)
+[types/subscription.ts:287](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/subscription.ts#L287)

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -70,6 +70,7 @@ export class AlgorandSubscriber {
     const pollResult = await getSubscribedTransactions(
       {
         watermark,
+        currentRound,
         ...this.config,
       },
       this.algod,

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -60,9 +60,9 @@ export async function getSubscribedTransactions(
   algod: Algodv2,
   indexer?: Indexer,
 ): Promise<TransactionSubscriptionResult> {
-  const { watermark, filters, maxRoundsToSync: _maxRoundsToSync, syncBehaviour: onMaxRounds } = subscription
+  const { watermark, filters, maxRoundsToSync: _maxRoundsToSync, syncBehaviour: onMaxRounds, currentRound: _currentRound } = subscription
   const maxRoundsToSync = _maxRoundsToSync ?? 500
-  const currentRound = (await algod.status().do())['last-round'] as number
+  const currentRound = _currentRound ?? ((await algod.status().do())['last-round'] as number)
   let blockMetadata: BlockMetadata[] | undefined
 
   // Pre-calculate a flat list of all ARC-28 events to process

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -248,6 +248,11 @@ export interface TransactionSubscriptionParams extends CoreTransactionSubscripti
    * will be slow if `onMaxRounds` is `sync-oldest`.
    **/
   watermark: number
+
+  /** The current tip of the configured Algorand blockchain.
+   * If not provided, it will be resolved on demand.
+   */
+  currentRound?: number
 }
 
 /** Configuration for an `AlgorandSubscriber`. */


### PR DESCRIPTION
I attempted to implement this as a `syncTo` feature as discussed here. https://github.com/algorandfoundation/algokit-subscriber-ts/pull/58#issuecomment-2066065152

Unfortunately both `getSubscribedTransactions` and `pollOnce` return the `currentRound` inside `TransactionSubscriptionResult`. If we wanted to support this properly, we'd need to make a breaking change and ensure the polling processes honour this configuration.

Instead I figured it was better to simply solve the problem at hand, which is preventing double status calls, when using `pollOnce`, which is what this PR does.