### PR TITLE
fix: some asset opt out transactions fail to decode

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -19,6 +19,9 @@ import OnApplicationComplete = algosdk.OnApplicationComplete
 import Transaction = algosdk.Transaction
 import TransactionType = algosdk.TransactionType
 
+export const ALGORAND_ZERO_ADDRESS = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ'
+export const ALGORAND_ZERO_ADDRESS_BYTES = algosdk.decodeAddress(ALGORAND_ZERO_ADDRESS).publicKey
+
 // Recursively remove all null values from object
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function removeNulls(obj: any) {
@@ -141,6 +144,11 @@ function extractTransactionFromBlockTransaction(
   // Unset gh if `hgh` is set to false
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ('hgh' in blockTransaction && blockTransaction.hgh === false) txn.gh = null as any
+
+  if (txn.type === TransactionType.axfer && !txn.arcv) {
+    // from_obj_for_encoding expects arcv to be set, which may not be defined when performing an opt out.
+    txn.arcv = Buffer.from(ALGORAND_ZERO_ADDRESS_BYTES)
+  }
 
   const t = Transaction.from_obj_for_encoding(txn)
   return {

--- a/tests/scenarios/transform-complex-txn.spec.ts
+++ b/tests/scenarios/transform-complex-txn.spec.ts
@@ -1,7 +1,8 @@
 import * as algokit from '@algorandfoundation/algokit-utils'
+import algosdk from 'algosdk'
 import { describe, expect, it } from 'vitest'
 import { getBlocksBulk } from '../../src/block'
-import { getBlockTransactions } from '../../src/transform'
+import { ALGORAND_ZERO_ADDRESS, getBlockTransactions } from '../../src/transform'
 import { GetSubscribedTransactions, clearUndefineds, getTransactionInBlockForDiff } from '../transactions'
 
 describe('Complex transaction with many nested inner transactions', () => {
@@ -641,5 +642,13 @@ describe('Complex transaction with many nested inner transactions', () => {
         },
       }
     `)
+  })
+
+  it('Transforms axfer without an arcv address', async () => {
+    const blocks = await getBlocksBulk({ startRound: 39373576, maxRound: 39373576 }, algod) // Contains an axfer opt out inner transaction without an arcv address
+    const blockTransactions = blocks.flatMap((b) => getBlockTransactions(b.block))
+
+    expect(blockTransactions.length).toBe(30)
+    expect(algosdk.encodeAddress(blockTransactions[5].blockTransaction.txn.arcv!)).toBe(ALGORAND_ZERO_ADDRESS)
   })
 })


### PR DESCRIPTION
Fix `address seems to be malformed` error experienced whilst live polling blocks.