### PR TITLE
fix: correctly handle when hgi field isn't set

### DIFF
--- a/docs/code/interfaces/types_block.BlockTransaction.md
+++ b/docs/code/interfaces/types_block.BlockTransaction.md
@@ -103,7 +103,7 @@ ___
 
 ### hgi
 
-• **hgi**: `boolean`
+• `Optional` **hgi**: `boolean`
 
 Has genesis id
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -136,14 +136,17 @@ function extractTransactionFromBlockTransaction(
   // https://github.com/algorand/js-algorand-sdk/blob/develop/examples/block_fetcher/index.ts
   // Remove nulls (mainly where an appl txn contains a null app arg)
   removeNulls(txn)
-  txn.gh = genesisHash
-  txn.gen = genesisId
-  // Unset gen if `hgi` isn't set
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ('hgi' in blockTransaction && !blockTransaction.hgi) txn.gen = null as any
-  // Unset gh if `hgh` is set to false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ('hgh' in blockTransaction && blockTransaction.hgh === false) txn.gh = null as any
+
+  // Add genesisId (gen) as the transaction was processed with it, and is required to generate the correct txID.
+  if ('hgi' in blockTransaction && blockTransaction.hgi === true) {
+    txn.gen = genesisId
+  }
+
+  // Add genesisHash (gh) as the transaction was processed with it, and is required to generate the correct txID.
+  // gh is mandatory on MainNet and TestNet (see https://forum.algorand.org/t/calculating-transaction-id/3119/7), so set gh unless hgh is explicitly false.
+  if (!('hgh' in blockTransaction) || blockTransaction.hgh !== false) {
+    txn.gh = genesisHash
+  }
 
   if (txn.type === TransactionType.axfer && !txn.arcv) {
     // from_obj_for_encoding expects arcv to be set, which may not be defined when performing an opt out.
@@ -193,17 +196,8 @@ function concatArrays(...arrs: ArrayLike<number>[]) {
   return c
 }
 
-function getTxIdFromBlockTransaction(blockTransaction: BlockTransaction, genesisHash: Buffer, genesisId: string): string {
+function getTxIdFromBlockTransaction(blockTransaction: BlockTransaction): string {
   const txn = blockTransaction.txn
-
-  txn.gh = genesisHash
-  txn.gen = genesisId
-  // Unset gen if `hgi` isn't set
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (!('hgi' in blockTransaction) || !blockTransaction.hgi) txn.gen = null as any
-  // Unset gh if `hgh` is set to false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ('hgh' in blockTransaction && blockTransaction.hgh === false) txn.gh = null as any
 
   // https://github.com/algorand/js-algorand-sdk/blob/develop/examples/block_fetcher/index.ts
   // Remove nulls (mainly where an appl txn contains a null app arg)
@@ -277,9 +271,8 @@ export function getIndexerTransactionFromAlgodTransaction(
   const stateProof = transaction.stateProof as unknown as StateProof | undefined
   const stateProofMessage = transaction.stateProofMessage as unknown as StateProofMessage | undefined
   const txId = // There is a bug in algosdk that means it can't calculate transaction IDs for stpf txns
-    transaction.type === TransactionType.stpf
-      ? getTxIdFromBlockTransaction(blockTransaction as BlockTransaction, genesisHash, genesisId)
-      : transaction.txID()
+    transaction.type === TransactionType.stpf ? getTxIdFromBlockTransaction(blockTransaction as BlockTransaction) : transaction.txID()
+
   try {
     // https://github.com/algorand/indexer/blob/main/api/converter_utils.go#L249
 

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -148,7 +148,7 @@ export interface BlockTransaction {
   /** Algo closing amount in microAlgos */
   ca?: number
   /** Has genesis id */
-  hgi: boolean
+  hgi?: boolean
   /** Has genesis hash */
   hgh?: boolean
   /** Transaction ED25519 signature */

--- a/tests/scenarios/transform-complex-txn.spec.ts
+++ b/tests/scenarios/transform-complex-txn.spec.ts
@@ -637,7 +637,7 @@ describe('Complex transaction with many nested inner transactions', () => {
     const blockTransactions = blocks.flatMap((b) => getBlockTransactions(b.block))
 
     expect(blockTransactions.length).toBe(30)
-    expect(algosdk.encodeAddress(blockTransactions[5].blockTransaction.txn.arcv!)).toBe(ALGORAND_ZERO_ADDRESS)
+    expect(algosdk.encodeAddress(blockTransactions[5].transaction.to.publicKey)).toBe(ALGORAND_ZERO_ADDRESS)
   })
 
   it('Produces the correct txID for a non hgi transaction', async () => {

--- a/tests/scenarios/transform-complex-txn.spec.ts
+++ b/tests/scenarios/transform-complex-txn.spec.ts
@@ -2,7 +2,7 @@ import * as algokit from '@algorandfoundation/algokit-utils'
 import algosdk from 'algosdk'
 import { describe, expect, it } from 'vitest'
 import { getBlocksBulk } from '../../src/block'
-import { ALGORAND_ZERO_ADDRESS, getBlockTransactions } from '../../src/transform'
+import { ALGORAND_ZERO_ADDRESS, getBlockTransactions, getIndexerTransactionFromAlgodTransaction } from '../../src/transform'
 import { GetSubscribedTransactions, clearUndefineds, getTransactionInBlockForDiff } from '../transactions'
 
 describe('Complex transaction with many nested inner transactions', () => {
@@ -212,7 +212,6 @@ describe('Complex transaction with many nested inner transactions', () => {
         ],
         "first-valid": 35214365,
         "genesis-hash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-        "genesis-id": "mainnet-v1.0",
         "group": "6ZssGapPFZ+DyccRludq0YjZigi05/FSeUAOFNDGGlo=",
         "id": "QLYC4KMQW5RZRA7W5GYCJ4CUVWWSZKMK2V4X3XFQYSGYCJH6LI4Q/inner/5",
         "inner-txns": [
@@ -244,7 +243,6 @@ describe('Complex transaction with many nested inner transactions', () => {
             "fee": 0,
             "first-valid": 35214365,
             "genesis-hash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-            "genesis-id": "mainnet-v1.0",
             "id": "QLYC4KMQW5RZRA7W5GYCJ4CUVWWSZKMK2V4X3XFQYSGYCJH6LI4Q/inner/5",
             "intra-round-offset": 148,
             "last-valid": 35214369,
@@ -365,7 +363,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "bLXdzryB627WoBOJ446eOJsiCi1Kfe/CKPTHRYKDsp0=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -403,7 +400,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "bLXdzryB627WoBOJ446eOJsiCi1Kfe/CKPTHRYKDsp0=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -429,7 +425,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "QDNLKZLNM6ZUD4ZI24RSY6O4QHWF3RHDQIYDV7S5AAHKFZSV2MSSULCE4U",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "lastRound": 35214369,
           "tag": "VFg=",
           "to": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
@@ -456,7 +451,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "6ZssGapPFZ+DyccRludq0YjZigi05/FSeUAOFNDGGlo=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -492,7 +486,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "6ZssGapPFZ+DyccRludq0YjZigi05/FSeUAOFNDGGlo=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -518,7 +511,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "RS7QNBEPRRIBGI5COVRWFCRUS5NC5NX7UABZSTSFXQ6F74EP3CNLT4CNAM",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "lastRound": 35214369,
           "tag": "VFg=",
           "to": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
@@ -545,7 +537,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "dsT4D4kYR3KthS3jbi4rJee2ej8gQChwzsQD8auclWw=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -583,7 +574,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "group": "dsT4D4kYR3KthS3jbi4rJee2ej8gQChwzsQD8auclWw=",
           "lastRound": 35214369,
           "tag": "VFg=",
@@ -608,7 +598,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "GJQLSF3KJZFRN7PMUYLDAOUVNHQVFMFXUNO6UPXVQH3GJXM5T53PF4TXEE",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "lastRound": 35214369,
           "tag": "VFg=",
           "to": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
@@ -633,7 +622,6 @@ describe('Complex transaction with many nested inner transactions', () => {
           "firstRound": 35214365,
           "from": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-          "genesisID": "mainnet-v1.0",
           "lastRound": 35214369,
           "reKeyTo": "AACCDJTFPQR5UQJZ337NFR56CC44T776EWBGVJG5NY2QFTQWBWTALTEN4A",
           "tag": "VFg=",
@@ -650,5 +638,14 @@ describe('Complex transaction with many nested inner transactions', () => {
 
     expect(blockTransactions.length).toBe(30)
     expect(algosdk.encodeAddress(blockTransactions[5].blockTransaction.txn.arcv!)).toBe(ALGORAND_ZERO_ADDRESS)
+  })
+
+  it('Produces the correct txID for a non hgi transaction', async () => {
+    const blocks = await getBlocksBulk({ startRound: 39430981, maxRound: 39430981 }, algod)
+    const blockTransactions = blocks.flatMap((b) => getBlockTransactions(b.block))
+
+    const transaction = getIndexerTransactionFromAlgodTransaction(blockTransactions[0])
+    expect(transaction.id).toBe('HHQHASIF2YLCSUYIPE6LIMLSNLCVMQBQHF3X46SKTX6F7ZSFKFCQ')
+    expect(transaction.id).toBe(blockTransactions[0].transaction.txID())
   })
 })

--- a/tests/scenarios/transform-stpf.spec.ts
+++ b/tests/scenarios/transform-stpf.spec.ts
@@ -3,13 +3,13 @@ import { TransactionType } from 'algosdk'
 import { describe, expect, it } from 'vitest'
 import { GetSubscribedTransactions, clearUndefineds } from '../transactions'
 
-describe('Complex transaction with many nested inner transactions', () => {
+describe('State proof transaction', () => {
   const txnId = 'G2U5DWQRQV7EGQDAHH62EDY22VYPP4VWM3V2S5BLDNXNWFNKRXMQ'
   const roundNumber = 35600004
   const algod = algokit.getAlgoClient(algokit.getAlgoNodeConfig('mainnet', 'algod'))
   const indexer = algokit.getAlgoIndexerClient(algokit.getAlgoNodeConfig('mainnet', 'indexer'))
 
-  it('Can have a keyreg transaction subscribed correctly from indexer', async () => {
+  it('Can have a stpf transaction subscribed correctly from indexer', async () => {
     const indexerTxns = await GetSubscribedTransactions(
       {
         filters: {
@@ -2104,7 +2104,7 @@ describe('Complex transaction with many nested inner transactions', () => {
     `)
   })
 
-  it('Can have an inner transaction subscribed correctly from algod', async () => {
+  it('Can have a stpf transaction subscribed correctly from algod', async () => {
     const algodTxns = await GetSubscribedTransactions(
       {
         filters: {
@@ -2132,7 +2132,6 @@ describe('Complex transaction with many nested inner transactions', () => {
         ],
         "first-valid": 35600002,
         "genesis-hash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-        "genesis-id": "mainnet-v1.0",
         "id": "G2U5DWQRQV7EGQDAHH62EDY22VYPP4VWM3V2S5BLDNXNWFNKRXMQ",
         "intra-round-offset": 1,
         "last-valid": 35601002,


### PR DESCRIPTION
## Proposed Changes

The `gen` field was added to a block transaction when `hgi` was not set. This resulted in an incorrect transaction id being computed.

This PR fixes that issue and adds a test to capture the scenario.