### PR TITLE
feat: trigger a breaking change again

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,4 @@ To try examples in this repository:
 
 - `npm install`
 - Copy `.env.sample` to `.env` and edit to point to the Algorand node you want to point to
-- `npm run dhm` or F5 in Visual Studio Code to get breakpoint debugging against one of the examples (or choose another)
+- `npm run dhm` or F5 in Visual Studio Code to get breakpoint debugging against one of the examples (or choose the other ones)


### PR DESCRIPTION
Just trying to correctly trigger a breaking change from the previous PR.

BREAKING CHANGE: `timestamp` in `BlockMetadata` is now an epoch seconds number, rather than an ISO8601 string to match other timestamps. `hash` and `previousBlockHash` in `BlockMetadata` are now base64 encoded strings, rather than base32 encoded strings. This matches the format used in the indexer api.