### PR TITLE
fix: handle optional stpf values

### DIFF
--- a/docs/code/interfaces/types_block.StateProof.md
+++ b/docs/code/interfaces/types_block.StateProof.md
@@ -20,39 +20,21 @@
 
 ### P
 
-• **P**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `hsh` | \{ `t`: `number`  } |
-| `hsh.t` | `number` |
-| `pth` | `Uint8Array`[] |
-| `td` | `number` |
+• **P**: `Proof`
 
 #### Defined in
 
-[types/block.ts:272](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L272)
+[types/block.ts:278](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L278)
 
 ___
 
 ### S
 
-• **S**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `hsh` | \{ `t`: `number`  } |
-| `hsh.t` | `number` |
-| `pth` | `Uint8Array`[] |
-| `td` | `number` |
+• **S**: `Proof`
 
 #### Defined in
 
-[types/block.ts:289](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L289)
+[types/block.ts:295](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L295)
 
 ___
 
@@ -62,7 +44,7 @@ ___
 
 #### Defined in
 
-[types/block.ts:271](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L271)
+[types/block.ts:277](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L277)
 
 ___
 
@@ -72,17 +54,17 @@ ___
 
 #### Defined in
 
-[types/block.ts:273](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L273)
+[types/block.ts:279](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L279)
 
 ___
 
 ### r
 
-• **r**: `Map`\<`number`, \{ `p`: \{ `p`: \{ `cmt`: `Uint8Array` ; `lf`: `number`  } ; `w`: `bigint`  } ; `s`: \{ `l?`: `bigint` ; `s`: \{ `idx`: `number` ; `prf`: \{ `hsh`: \{ `t`: `number`  } ; `pth`: `Uint8Array`[] ; `td`: `number`  } ; `sig`: `Uint8Array` ; `vkey`: \{ `k`: `Uint8Array`  }  }  }  }\>
+• **r**: `Map`\<`number`, \{ `p`: \{ `p`: \{ `cmt`: `Uint8Array` ; `lf`: `number`  } ; `w`: `bigint`  } ; `s`: \{ `l?`: `bigint` ; `s`: \{ `idx`: `number` ; `prf`: `Proof` ; `sig`: `Uint8Array` ; `vkey`: \{ `k`: `Uint8Array`  }  }  }  }\>
 
 #### Defined in
 
-[types/block.ts:274](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L274)
+[types/block.ts:280](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L280)
 
 ___
 
@@ -92,7 +74,7 @@ ___
 
 #### Defined in
 
-[types/block.ts:291](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L291)
+[types/block.ts:297](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L297)
 
 ___
 
@@ -102,4 +84,4 @@ ___
 
 #### Defined in
 
-[types/block.ts:290](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L290)
+[types/block.ts:296](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L296)

--- a/docs/code/interfaces/types_block.StateProofMessage.md
+++ b/docs/code/interfaces/types_block.StateProofMessage.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[types/block.ts:298](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L298)
+[types/block.ts:304](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L304)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[types/block.ts:295](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L295)
+[types/block.ts:301](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L301)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[types/block.ts:296](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L296)
+[types/block.ts:302](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L302)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[types/block.ts:297](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L297)
+[types/block.ts:303](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L303)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[types/block.ts:299](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L299)
+[types/block.ts:305](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L305)

--- a/docs/code/interfaces/types_block.StateProofTracking.md
+++ b/docs/code/interfaces/types_block.StateProofTracking.md
@@ -22,7 +22,7 @@ StateProofNextRound is the next round for which we will accept a StateProof tran
 
 #### Defined in
 
-[types/block.ts:317](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L317)
+[types/block.ts:323](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L323)
 
 ___
 
@@ -36,7 +36,7 @@ This is intended for computing the threshold of votes to expect from StateProofV
 
 #### Defined in
 
-[types/block.ts:313](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L313)
+[types/block.ts:319](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L319)
 
 ___
 
@@ -51,4 +51,4 @@ For blocks that are not a multiple of ConsensusParams.StateProofRounds, this val
 
 #### Defined in
 
-[types/block.ts:308](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L308)
+[types/block.ts:314](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L314)

--- a/docs/code/interfaces/types_block.TransactionInBlock.md
+++ b/docs/code/interfaces/types_block.TransactionInBlock.md
@@ -40,7 +40,7 @@ The asset close amount if the sender asset position was closed from this transac
 
 #### Defined in
 
-[types/block.ts:385](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L385)
+[types/block.ts:391](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L391)
 
 ___
 
@@ -52,7 +52,7 @@ The block data for the transaction
 
 #### Defined in
 
-[types/block.ts:327](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L327)
+[types/block.ts:333](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L333)
 
 ___
 
@@ -64,7 +64,7 @@ The ALGO close amount if the sender account was closed from this transaction.
 
 #### Defined in
 
-[types/block.ts:387](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L387)
+[types/block.ts:393](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L393)
 
 ___
 
@@ -76,7 +76,7 @@ Rewards in microalgos applied to the close remainder to account.
 
 #### Defined in
 
-[types/block.ts:391](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L391)
+[types/block.ts:397](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L397)
 
 ___
 
@@ -88,7 +88,7 @@ The app ID if an app was created from this transaction.
 
 #### Defined in
 
-[types/block.ts:383](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L383)
+[types/block.ts:389](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L389)
 
 ___
 
@@ -100,7 +100,7 @@ The asset ID if an asset was created from this transaction.
 
 #### Defined in
 
-[types/block.ts:381](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L381)
+[types/block.ts:387](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L387)
 
 ___
 
@@ -112,7 +112,7 @@ The binary genesis hash of the network the transaction is within.
 
 #### Defined in
 
-[types/block.ts:368](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L368)
+[types/block.ts:374](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L374)
 
 ___
 
@@ -124,7 +124,7 @@ The string genesis ID of the network the transaction is within.
 
 #### Defined in
 
-[types/block.ts:370](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L370)
+[types/block.ts:376](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L376)
 
 ___
 
@@ -136,7 +136,7 @@ Any logs that were issued as a result of this transaction.
 
 #### Defined in
 
-[types/block.ts:389](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L389)
+[types/block.ts:395](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L395)
 
 ___
 
@@ -159,7 +159,7 @@ The offset within the parent transaction.
 
 #### Defined in
 
-[types/block.ts:366](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L366)
+[types/block.ts:372](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L372)
 
 ___
 
@@ -171,7 +171,7 @@ The ID of the parent transaction if this is an inner transaction.
 
 #### Defined in
 
-[types/block.ts:354](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L354)
+[types/block.ts:360](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L360)
 
 ___
 
@@ -183,7 +183,7 @@ Rewards in microalgos applied to the receiver account.
 
 #### Defined in
 
-[types/block.ts:395](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L395)
+[types/block.ts:401](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L401)
 
 ___
 
@@ -206,7 +206,7 @@ The index within the block.txns array of this transaction or if it's an inner tr
 
 #### Defined in
 
-[types/block.ts:350](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L350)
+[types/block.ts:356](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L356)
 
 ___
 
@@ -218,7 +218,7 @@ The round number of the block the transaction is within.
 
 #### Defined in
 
-[types/block.ts:372](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L372)
+[types/block.ts:378](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L378)
 
 ___
 
@@ -241,7 +241,7 @@ The offset of the transaction within the round including inner transactions.
 
 #### Defined in
 
-[types/block.ts:338](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L338)
+[types/block.ts:344](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L344)
 
 ___
 
@@ -253,7 +253,7 @@ The round unix timestamp of the block the transaction is within.
 
 #### Defined in
 
-[types/block.ts:374](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L374)
+[types/block.ts:380](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L380)
 
 ___
 
@@ -265,7 +265,7 @@ Rewards in microalgos applied to the sender account.
 
 #### Defined in
 
-[types/block.ts:393](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L393)
+[types/block.ts:399](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L399)
 
 ___
 
@@ -277,4 +277,4 @@ The transaction as an algosdk `Transaction` object.
 
 #### Defined in
 
-[types/block.ts:379](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L379)
+[types/block.ts:385](https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/src/types/block.ts#L385)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -425,8 +425,8 @@ export function getIndexerTransactionFromAlgodTransaction(
                   'hash-factory': {
                     'hash-type': stateProof!.P.hsh.t,
                   },
-                  'tree-depth': stateProof!.P.td,
-                  path: stateProof!.P.pth.map((p) => Buffer.from(p).toString('base64')),
+                  'tree-depth': stateProof!.P.td ?? 0,
+                  path: stateProof!.P.pth?.map((p) => Buffer.from(p).toString('base64')) ?? [],
                 },
                 'positions-to-reveal': stateProof!.pr,
                 'salt-version': Number(stateProof!.v ?? 0),
@@ -435,8 +435,8 @@ export function getIndexerTransactionFromAlgodTransaction(
                   'hash-factory': {
                     'hash-type': stateProof!.S.hsh.t,
                   },
-                  'tree-depth': stateProof!.S.td,
-                  path: stateProof!.S.pth.map((p) => Buffer.from(p).toString('base64')),
+                  'tree-depth': stateProof!.S.td ?? 0,
+                  path: stateProof!.S.pth?.map((p) => Buffer.from(p).toString('base64')) ?? [],
                 },
                 'signed-weight': Number(stateProof!.w),
                 reveals: mapKeys(stateProof!.r).map((position) => {
@@ -451,8 +451,8 @@ export function getIndexerTransactionFromAlgodTransaction(
                           'hash-factory': {
                             'hash-type': r.s.s.prf.hsh.t,
                           },
-                          'tree-depth': r.s.s.prf.td,
-                          path: r.s.s.prf.pth.map((p) => Buffer.from(p).toString('base64')),
+                          'tree-depth': r.s.s.prf.td ?? 0,
+                          path: r.s.s.prf.pth?.map((p) => Buffer.from(p).toString('base64')) ?? [],
                         },
                         'verifying-key': Buffer.from(r.s.s.vkey.k).toString('base64'),
                       },

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -266,10 +266,16 @@ export interface BlockValueDelta {
   ui?: number
 }
 
+interface Proof {
+  hsh: { t: number }
+  pth?: Uint8Array[]
+  td?: number
+}
+
 // https://github.com/algorand/go-algorand-sdk/blob/develop/types/stateproof.go
 export interface StateProof {
   c: Uint8Array
-  P: { hsh: { t: number }; pth: Uint8Array[]; td: number }
+  P: Proof
   pr: number[]
   r: Map<
     number,
@@ -279,14 +285,14 @@ export interface StateProof {
         l?: bigint
         s: {
           idx: number
-          prf: { hsh: { t: number }; pth: Uint8Array[]; td: number }
+          prf: Proof
           sig: Uint8Array
           vkey: { k: Uint8Array }
         }
       }
     }
   >
-  S: { hsh: { t: number }; pth: Uint8Array[]; td: number }
+  S: Proof
   w: bigint
   v?: number
 }


### PR DESCRIPTION
Both `pth` and `td` are optional inside a stateproof proof.

Fixes https://github.com/algorandfoundation/algokit-subscriber-ts/issues/93