### PR TITLE
bug: fix the transform logic for app call transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6354,12 +6354,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -363,7 +363,7 @@ export function getIndexerTransactionFromAlgodTransaction(
       ...(transaction.type === TransactionType.appl
         ? {
             'application-transaction': {
-              'application-id': transaction.appIndex,
+              'application-id': transaction.appIndex ?? 0,
               'approval-program':
                 transaction.appApprovalProgram && transaction.appApprovalProgram.length > 0
                   ? Buffer.from(transaction.appApprovalProgram).toString('base64')

--- a/tests/scenarios/app-call-transactions.spec.ts
+++ b/tests/scenarios/app-call-transactions.spec.ts
@@ -1,0 +1,62 @@
+import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
+import { Account } from 'algosdk'
+import { afterEach, beforeEach, describe, expect, test, vitest } from 'vitest'
+import { TestingAppClient } from '../contract/client'
+import { GetSubscribedTransactions, SendXTransactions } from '../transactions'
+
+describe('App call transactions', () => {
+  const localnet = algorandFixture()
+  beforeEach(localnet.beforeEach, 10e6)
+  afterEach(() => {
+    vitest.clearAllMocks()
+  })
+
+  describe('Can have an app create transaction subscribed correctly from algod', () => {
+    const app = async (config: { create: boolean }, creator: Account) => {
+      const app = new TestingAppClient(
+        {
+          resolveBy: 'id',
+          id: 0,
+        },
+        localnet.context.algod,
+      )
+      const creation = await app.create.bare({
+        sender: creator,
+        sendParams: {
+          skipSending: !config.create,
+        },
+      })
+
+      return {
+        app,
+        creation,
+      }
+    }
+
+    test('Works for app create', async () => {
+      const { testAccount } = localnet.context
+      const app1 = await app({ create: true }, testAccount)
+
+      // Ensure there is another transaction so algod subscription can process something
+      await SendXTransactions(1, testAccount, localnet.context.algod)
+      // Wait for indexer to catch up
+      await localnet.context.waitForIndexer()
+
+      const [algod] = await Promise.all([
+        GetSubscribedTransactions(
+          {
+            roundsToSync: 1,
+            syncBehaviour: 'sync-oldest',
+            watermark: Number(app1.creation.confirmation?.confirmedRound) - 1,
+            currentRound: Number(app1.creation.confirmation?.confirmedRound),
+            filters: { appCreate: true },
+          },
+          localnet.context.algod,
+        ),
+      ])
+
+      expect(algod.subscribedTransactions.length).toBe(1)
+      expect(algod.subscribedTransactions[0]['application-transaction']?.['application-id']).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Proposed Changes

- Update the transform logic for app call transaction to assign 0 to the `application-id` field when `transaction.appIndex` is falsy. This is because for an app create transaction, the value of `transaction.appIndex` is `undefined`, causing 'application-id' to be `undefined` too. Indexer requires `application-id` to be 0 for app create transactions.
