### PR TITLE
Chore/bot token workflow

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -3,8 +3,6 @@ name: Prod Publish
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
 
 jobs:
   prod_release:

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -10,17 +10,31 @@ jobs:
   prod_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
+      # Step to generate the bot token for semantic release
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.BOT_ID}}
+          private_key: ${{ secrets.BOT_SK }}
+
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
+
+      # Set git user to the GitHub App
+      - name: Set Git user as GitHub actions
+        run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
+
+
       - name: Merge main -> release
         uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
         with:
           type: now
           from_branch: main
           target_branch: release
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app_token.outputs.token }}
       - name: Merge release -> main
         uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
         with:
@@ -28,4 +42,4 @@ jobs:
           from_branch: release
           target_branch: main
           message: Merge release back to main to get version increment [no ci]
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,6 @@ on:
 
 concurrency: release
 
-permissions:
-  contents: write
-  issues: write
-  checks: write
-
 jobs:
   ci:
     name: Continuous Integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      # Step to generate the bot token for semantic release
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.BOT_ID}}
+          private_key: ${{ secrets.BOT_SK }}
+
+        uses: actions/checkout@v4
+        with:
+        fetch-depth: 0
+        token: ${{ steps.app_token.outputs.token }}
 
       # semantic-release needs node 20
       - name: Use Node.js 20.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,5 +102,5 @@ jobs:
       - name: 'Semantic release'
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       # Step to generate the bot token for semantic release
       - name: Generate bot token
         uses: actions/create-github-app-token@v1
@@ -73,10 +74,14 @@ jobs:
           app_id: ${{ secrets.BOT_ID}}
           private_key: ${{ secrets.BOT_SK }}
 
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-        fetch-depth: 0
-        token: ${{ steps.app_token.outputs.token }}
+          fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
+
+      # Set git user to the GitHub App
+      - name: Set Git user as GitHub actions
+        run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       # semantic-release needs node 20
       - name: Use Node.js 20.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,5 +102,6 @@ jobs:
       - name: 'Semantic release'
         run: npx semantic-release
         env:
+          # Use the GitHub App token for authentication
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       # Step to generate the bot token for semantic release
       - name: Generate bot token


### PR DESCRIPTION
Updated algokit-subscriber-ts CD to use the engineering-ci GitHub Org App token instead of the default GITHUB_TOKEN in the release workflow.

- Added step: `Generate bot token` to set the token variable
- Added step `Set Git user as GitHub actions` to use credentials
- Updated semantic release to use generated token instead of GITHUB_TOKEN 
