### PR TITLE
docs: add auto-generated example pages to documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ __pycache__
 
 *.db
 *.db-journal
+
+
+.claude/

--- a/.nsprc
+++ b/.nsprc
@@ -9,19 +9,14 @@
     "notes": "tar via npm in @semantic-release/npm - waiting for upstream fix",
     "expiry": "2026-03-17"
   },
-  "1113214": {
+  "1113375": {
     "active": true,
-    "notes": "ajv v6 is a peer dependency of eslint v8 (via typescript-eslint) - requires eslint v9 migration to resolve",
+    "notes": "tar arbitrary file read/write via hardlink target escape (npm>tar) - tar is bundled inside npm, overrides cannot fix bundled deps, waiting for upstream fix",
     "expiry": "2026-06-01"
   },
-  "1113249": {
+  "1113371": {
     "active": true,
-    "notes": "tar is bundled inside npm - overrides cannot fix bundled deps, waiting for upstream fix",
-    "expiry": "2026-06-01"
-  },
-  "1113296": {
-    "active": true,
-    "notes": "minimatch ReDoS via glob, test-exclude, typescript-eslint, eslint v8, npm — requires eslint v9 + vitest v4 migration or upstream fix",
+    "notes": "minimatch ReDoS via repeated wildcards (glob, npm, test-exclude, typescript-eslint) — npm>minimatch is bundled inside npm, overrides cannot fix bundled deps, waiting for upstream fix or vitest v4 + eslint v9 migration",
     "expiry": "2026-06-01"
   }
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,6 +15,11 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'AlgoKit Subscriber TypeScript',
+      customCss: [
+        'remark-github-alerts/styles/github-colors-light.css',
+        'remark-github-alerts/styles/github-colors-dark-media.css',
+        'remark-github-alerts/styles/github-base.css',
+      ],
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/algorandfoundation/algokit-subscriber-ts' },
         { icon: 'discord', label: 'Discord', href: 'https://discord.gg/algorand' },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -62,6 +62,10 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Examples',
+          items: [{ label: 'Overview', link: '/examples/' }],
+        },
+        {
           label: 'Migration Guides',
           collapsed: true,
           autogenerate: { directory: 'migration' },

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,21 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
+import { examplesLoader } from './loaders/examples-loader';
 
 export const collections = {
 	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+	examples: defineCollection({
+		loader: examplesLoader(),
+		schema: z.object({
+			id: z.string(),
+			title: z.string(),
+			description: z.string(),
+			prerequisites: z.string(),
+			code: z.string(),
+			order: z.number(),
+			filename: z.string(),
+			runCommand: z.string(),
+		}),
+	}),
 };

--- a/docs/src/loaders/examples-loader.ts
+++ b/docs/src/loaders/examples-loader.ts
@@ -1,0 +1,146 @@
+import type { Loader } from 'astro/loaders'
+import fs from 'node:fs'
+import path from 'node:path'
+
+type ExampleEntry = {
+  id: string
+  title: string
+  description: string
+  prerequisites: string
+  code: string
+  order: number
+  filename: string
+  runCommand: string
+}
+
+function lineSeparator(text: string, isBullet: boolean, lastWasBullet: boolean): string {
+  if (!text) return ''
+  if (isBullet || lastWasBullet) return '\n'
+  return ' '
+}
+
+function parseJSDoc(content: string): { title: string; description: string; prerequisites: string } {
+  const jsdocMatch = content.match(/\/\*\*\n([\s\S]*?)\*\//)
+
+  if (!jsdocMatch) {
+    return { title: 'Example', description: '', prerequisites: '' }
+  }
+
+  const jsdocContent = jsdocMatch[1]
+
+  // Extract title from "Example: Title" line
+  const titleMatch = jsdocContent.match(/\*\s*Example:\s*(.+)/)
+  const title = titleMatch?.[1]?.trim() || 'Example'
+
+  // Extract description - lines after title until Prerequisites or end
+  const lines = jsdocContent.split('\n').map((line) => line.replace(/^\s*\*\s?/, '').trim())
+
+  let description = ''
+  let prerequisites = ''
+  let inPrerequisites = false
+  let lastLineWasBullet = false
+
+  for (const line of lines) {
+    if (line.startsWith('Example:')) continue
+
+    if (line.toLowerCase().startsWith('prerequisites:') || line.toLowerCase() === 'prerequisites') {
+      inPrerequisites = true
+      lastLineWasBullet = false
+      const prereqContent = line.replace(/prerequisites:?\s*/i, '').trim()
+      if (prereqContent) prerequisites = prereqContent
+      continue
+    }
+
+    if (line.startsWith('@')) continue
+
+    if (!line) {
+      lastLineWasBullet = false
+      if (inPrerequisites) {
+        if (prerequisites) prerequisites += '\n'
+      } else if (description) {
+        description += '\n'
+      }
+      continue
+    }
+
+    const isBullet = line.startsWith('-') || line.startsWith('•')
+    if (inPrerequisites) {
+      prerequisites += lineSeparator(prerequisites, isBullet, lastLineWasBullet) + line
+    } else {
+      description += lineSeparator(description, isBullet, lastLineWasBullet) + line
+    }
+    lastLineWasBullet = isBullet
+  }
+
+  return {
+    title,
+    description: description.trim(),
+    prerequisites: prerequisites.trim() || 'LocalNet running (`algokit localnet start`)',
+  }
+}
+
+/**
+ * Extract order number from filename (e.g., "01-example.ts" -> 1)
+ */
+function extractOrder(filename: string): number {
+  const match = filename.match(/^(\d+)-/)
+  return match ? parseInt(match[1], 10) : 999
+}
+
+function createSlug(filename: string): string {
+  return filename.replace(/\.ts$/, '').replace(/_/g, '-')
+}
+
+export function examplesLoader(): Loader {
+  return {
+    name: 'examples-loader',
+    load: async ({ store, logger }) => {
+      const examplesDir = path.resolve(process.cwd(), '..', 'examples', 'subscriber')
+
+      logger.info(`Loading examples from ${examplesDir}`)
+
+      if (!fs.existsSync(examplesDir)) {
+        logger.error(`Examples directory not found: ${examplesDir}`)
+        return
+      }
+
+      const entries: ExampleEntry[] = []
+
+      const files = fs.readdirSync(examplesDir).filter((f) => f.endsWith('.ts') && !f.startsWith('_'))
+
+      for (const filename of files) {
+        const filePath = path.join(examplesDir, filename)
+        const content = fs.readFileSync(filePath, 'utf-8')
+        const { title, description, prerequisites } = parseJSDoc(content)
+        const order = extractOrder(filename)
+        const slug = createSlug(filename)
+
+        const entry: ExampleEntry = {
+          id: slug,
+          title,
+          description,
+          prerequisites,
+          code: content,
+          order,
+          filename,
+          runCommand: `npm run example ${filename}`,
+        }
+
+        entries.push(entry)
+      }
+
+      entries.sort((a, b) => a.order - b.order)
+
+      logger.info(`Found ${entries.length} examples`)
+
+      for (const entry of entries) {
+        store.set({
+          id: entry.id,
+          data: entry,
+        })
+      }
+    },
+  }
+}
+
+export type { ExampleEntry }

--- a/docs/src/pages/examples/[...slug].astro
+++ b/docs/src/pages/examples/[...slug].astro
@@ -1,0 +1,103 @@
+---
+import { getCollection } from 'astro:content'
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+import { Code } from '@astrojs/starlight/components'
+
+export async function getStaticPaths() {
+  const examples = await getCollection('examples')
+  return examples.map((example) => ({
+    params: { slug: example.id },
+    props: { example },
+  }))
+}
+
+const { example } = Astro.props
+const { title, description, prerequisites, code, filename, runCommand } = example.data
+
+// Get all examples for sidebar navigation
+const allExamples = await getCollection('examples')
+const sortedExamples = allExamples.sort((a, b) => a.data.order - b.data.order)
+
+// GitHub source URL
+const githubUrl = `https://github.com/algorandfoundation/algokit-subscriber-ts/blob/main/examples/subscriber/${filename}`
+---
+
+<StarlightPage
+  frontmatter={{
+    title: title,
+    description: description,
+  }}
+  headings={[
+    { depth: 2, text: 'Description', slug: 'description' },
+    { depth: 2, text: 'Prerequisites', slug: 'prerequisites' },
+    { depth: 2, text: 'Run This Example', slug: 'run-this-example' },
+    { depth: 2, text: 'Code', slug: 'code' },
+  ]}
+>
+  <p><a href="/algokit-subscriber-ts/examples/">&larr; Back to Examples</a></p>
+
+  <h2 id="description">Description</h2>
+  {(() => {
+    const text = description || 'This example demonstrates usage of the AlgoKit Subscriber TypeScript library.'
+    const lines = text.split('\n')
+    const elements: any[] = []
+    let bulletBuffer: string[] = []
+
+    const flushBullets = () => {
+      if (bulletBuffer.length > 0) {
+        elements.push(<ul>{bulletBuffer.map((b) => <li set:html={b} />)}</ul>)
+        bulletBuffer = []
+      }
+    }
+
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      if (/^[-•]\s/.test(trimmed)) {
+        bulletBuffer.push(trimmed.replace(/^[-•]\s*/, ''))
+      } else {
+        flushBullets()
+        elements.push(<p set:html={trimmed} />)
+      }
+    }
+    flushBullets()
+    return elements
+  })()}
+
+  <h2 id="prerequisites">Prerequisites</h2>
+  <ul>
+    {
+      prerequisites.split('\n').map((prereq) => {
+        const text = prereq.replace(/^[-•]\s*/, '').trim()
+        return text ? <li set:html={text} /> : null
+      })
+    }
+  </ul>
+
+  <h2 id="run-this-example">Run This Example</h2>
+  <p>From the <code>examples/subscriber</code> directory:</p>
+  <Code code={runCommand} lang="bash" />
+
+  <h2 id="code">Code</h2>
+  <p>
+    <a href={githubUrl} target="_blank" rel="noopener noreferrer">View source on GitHub &rarr;</a>
+  </p>
+  <Code code={code} lang="typescript" title={filename} />
+
+  <hr />
+
+  <h3>All Examples</h3>
+  <ul>
+    {
+      sortedExamples.map((e) => (
+        <li>
+          {e.id === example.id ? (
+            <strong>{e.data.title}</strong>
+          ) : (
+            <a href={`/algokit-subscriber-ts/examples/${e.id}/`}>{e.data.title}</a>
+          )}
+        </li>
+      ))
+    }
+  </ul>
+</StarlightPage>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -1,0 +1,92 @@
+---
+import { getCollection } from 'astro:content'
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+
+const allExamples = await getCollection('examples')
+const sortedExamples = allExamples.sort((a, b) => a.data.order - b.data.order)
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Code Examples',
+    description: `${allExamples.length} runnable TypeScript examples demonstrating AlgoKit Subscriber features`,
+  }}
+>
+  <p>
+    Browse <strong>{allExamples.length}</strong> runnable TypeScript examples demonstrating how to use the AlgoKit
+    Subscriber library. Each example is self-contained and progressively introduces features.
+  </p>
+
+  <h2>Quick Start</h2>
+  <pre><code>{`# Clone the repository
+git clone https://github.com/algorandfoundation/algokit-subscriber-ts.git
+cd algokit-subscriber-ts
+
+# Install dependencies and build the package
+npm ci
+npm run build
+
+# Install examples dependencies
+cd examples/subscriber
+npm ci
+
+# Run any example
+npm run example 01-basic-poll-once.ts`}</code></pre>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li>Node.js &gt;= 20.0</li>
+    <li>
+      <a href="https://github.com/algorandfoundation/algokit-cli">AlgoKit CLI</a> installed
+    </li>
+    <li>
+      LocalNet running (<code>algokit localnet start</code>)
+    </li>
+  </ul>
+
+  <h2>Examples ({allExamples.length})</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Example</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        sortedExamples.map((example) => (
+          <tr>
+            <td>
+              <a href={`/algokit-subscriber-ts/examples/${example.id}/`}>{example.data.title}</a>
+            </td>
+            <td>{(() => {
+              const text = example.data.description || ''
+              const lines = text.split('\n')
+              const elements: any[] = []
+              let bulletBuffer: string[] = []
+              const flushBullets = () => {
+                if (bulletBuffer.length > 0) {
+                  elements.push(<ul>{bulletBuffer.map((b) => <li set:html={b} />)}</ul>)
+                  bulletBuffer = []
+                }
+              }
+              for (const line of lines) {
+                const trimmed = line.trim()
+                if (!trimmed) continue
+                if (/^[-•]\s/.test(trimmed)) {
+                  bulletBuffer.push(trimmed.replace(/^[-•]\s*/, ''))
+                } else {
+                  flushBullets()
+                  elements.push(<p set:html={trimmed} />)
+                }
+              }
+              flushBullets()
+              return elements
+            })()}</td>
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</StarlightPage>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2927,10 +2927,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
   "overrides": {
     "esbuild": "0.25.0",
     "js-yaml": "4.1.1",
-    "glob": "^11.1.0"
+    "glob": "^11.1.0",
+    "ajv": "^6.14.0"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Adds auto-generated example pages to the Starlight documentation site, so the 15 runnable subscriber examples are browsable directly in the docs. I only added the auto-generate examples. We should consider what we do with the other examples that exist in the `examples` dir (i.e. not in the `examples/subscriber` dir)

A custom Astro content loader scans examples/subscriber/*.ts at build time, parses JSDoc headers for title/description/prerequisites, and feeds them into an Astro content collection. Two dynamic page routes render an examples overview listing and individual detail pages with syntax-highlighted source code, run commands, and GitHub source links.

This follows the same pattern used in algokit-utils-ts but simplified to a flat list since all examples live in a single directory rather than multiple categories.

<img width="1443" height="928" alt="image" src="https://github.com/user-attachments/assets/73df1e64-3597-4ce7-a00c-3125f7512a0a" />
