### PR TITLE
docs: fix 404 urls and add api modules

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight';
 import starlightTypeDoc from 'starlight-typedoc';
 import sidebar from './sidebar.config.json';
 import remarkGithubAlerts from 'remark-github-alerts';
+import remarkFixIndexUrls from './plugins/remark-fix-index-urls';
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,7 +12,7 @@ export default defineConfig({
   base: '/algokit-subscriber-ts/',
   trailingSlash: 'always',
   markdown: {
-    remarkPlugins: [remarkGithubAlerts],
+    remarkPlugins: [remarkGithubAlerts, remarkFixIndexUrls],
   },
   integrations: [
     starlight({

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,9 @@
     "astro": "astro"
   },
   "devDependencies": {
-    "tsx": "^4.21.0"
+    "@types/mdast": "^4.0.4",
+    "tsx": "^4.21.0",
+    "unist-util-visit": "^5.1.0"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.37.6",

--- a/docs/plugins/remark-fix-index-urls.ts
+++ b/docs/plugins/remark-fix-index-urls.ts
@@ -1,0 +1,17 @@
+import type { Link, Root } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+/**
+ * Remark plugin that removes trailing `/index/` from internal links.
+ *
+ * Starlight serves `index.md` files at the parent directory URL, but
+ * starlight-typedoc generates links with an explicit `/index/` segment.
+ * e.g. `/algokit-subscriber-ts/api/algokit-subscriber/index/` → `/algokit-subscriber-ts/api/algokit-subscriber/`
+ */
+export default function remarkFixIndexUrls() {
+  return (tree: Root) => {
+    visit(tree, 'link', (node: Link) => {
+      node.url = node.url.replace(/\/index\/$/, '/')
+    })
+  }
+}

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -30,9 +30,15 @@ importers:
         specifier: ^4.10.0
         version: 4.10.0(typedoc@0.28.17(typescript@5.9.3))
     devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
 
 packages:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
+/**
+ * @module algokit-subscriber
+ */
 export * from './subscriber'
 export * from './subscriptions'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @module algokit-subscriber/types
+ */
 export type * from './arc-28'
 export type * from './async-event-emitter'
 export type * from './block'


### PR DESCRIPTION
## Summary

- Add remark plugin (`remark-fix-index-urls`) to strip trailing `/index/` from internal links generated by `starlight-typedoc`, which were causing 404s since Starlight serves `index.md` at the parent directory URL
- Add `@module` JSDoc tags to barrel export files (`src/index.ts`, `src/types/index.ts`) so typedoc generates proper module pages in the API docs