### PR TITLE
chore: bump algokit-utils to beta.3, harden workflows and retire alpha channel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - alpha
 
 permissions:
   contents: read
@@ -25,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
           cache: 'npm'

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -4,21 +4,21 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prod_release:
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
@@ -27,7 +27,7 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       - name: Merge main -> release
-        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: main
@@ -35,7 +35,7 @@ jobs:
           github_token: ${{ steps.app_token.outputs.token }}
 
       - name: Merge release -> main
-        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: release

--- a/.github/workflows/publish-devportal-docs.yml
+++ b/.github/workflows/publish-devportal-docs.yml
@@ -3,7 +3,7 @@ name: Publish DevPortal Docs
 on:
   workflow_dispatch:
   push:
-    branches: [ci/add-publish-to-devportal-workflow]
+    branches: [main]
     tags: ['v*']
 
 permissions:
@@ -13,13 +13,13 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           package_json_file: docs/package.json
 
@@ -30,6 +30,6 @@ jobs:
         run: npm run build
 
       - name: Publish DevPortal Docs
-        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@ci/update-publish-devportal-docs-workflow
+        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@release/ak-v4
         with:
           docs-dir: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,12 @@ on:
     branches:
       - main
       - release
-      - alpha
   workflow_dispatch:
 
 concurrency: release
 
 permissions:
-  contents: write
-  issues: read
-  id-token: write
+  contents: read
 
 jobs:
   ci:
@@ -45,14 +42,14 @@ jobs:
       id-token: write
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
@@ -61,12 +58,12 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: package
           path: artifacts
@@ -87,7 +84,7 @@ jobs:
 
   publish_docs:
     name: Publish docs to GitHub Pages
-    needs: check_docs
+    needs: release
     if: github.ref_name == 'release'
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const subscriber = new AlgorandSubscriber(
       {
         name: "filter1",
         filter: {
-          type: TransactionType.pay,
+          type: TransactionType.Payment,
           sender: "ABC...",
         },
       },
@@ -145,7 +145,7 @@ const subscriber = new AlgorandSubscriber(
       {
         name: "dhm-asset",
         filter: {
-          type: TransactionType.acfg,
+          type: TransactionType.AssetConfig,
           // Data History Museum creator account on TestNet
           sender: "ER7AMZRPD5KDVFWTUUVOADSOWM4RQKEEV2EDYRVSA757UHXOIEKGMBQIVU",
         },
@@ -195,7 +195,7 @@ const subscriber = new AlgorandSubscriber(
       {
         name: "usdc",
         filter: {
-          type: TransactionType.axfer,
+          type: TransactionType.AssetTransfer,
           assetId: 31566704n, // MainNet: USDC
           minAmount: 1_000_000n, // $1
         },

--- a/docs/src/content/docs/concepts/filtering.md
+++ b/docs/src/content/docs/concepts/filtering.md
@@ -18,7 +18,7 @@ getSubscribedTransactions({filters: [{name: 'filterName', filter: {/* Filter pro
 
 Currently this allows you filter based on any combination (AND logic) of:
 
-- Transaction type e.g. `filter: { type: TransactionType.axfer }` or `filter: {type: [TransactionType.axfer, TransactionType.pay] }`
+- Transaction type e.g. `filter: { type: TransactionType.AssetTransfer }` or `filter: {type: [TransactionType.AssetTransfer, TransactionType.Payment] }`
 - Account (sender and receiver) e.g. `filter: { sender: "ABCDE..F" }` or `filter: { sender: ["ABCDE..F", "ZYXWV..A"] }` and `filter: { receiver: "12345..6" }` or `filter: { receiver: ["ABCDE..F", "ZYXWV..A"] }`
 - Note prefix e.g. `filter: { notePrefix: "xyz" }`
 - Apps
@@ -47,10 +47,10 @@ Currently this allows you filter based on any combination (AND logic) of:
 - Assets
   - ID e.g. `filter: { assetId: 123456n }` or `filter: { assetId: [123456n, 456789n] }`
   - Creation e.g. `filter: { assetCreate: true }`
-  - Amount transferred (min and/or max) e.g. `filter: { type: TransactionType.axfer, minAmount: 1, maxAmount: 100 }`
+  - Amount transferred (min and/or max) e.g. `filter: { type: TransactionType.AssetTransfer, minAmount: 1, maxAmount: 100 }`
   - Balance changes (asset ID, sender, receiver, close to, min and/or max change) e.g. `filter: { balanceChanges: [{assetId: [15345n, 36234n], role: [BalanceChangeRole.Sender], address: "ABC...", minAmount: 1, maxAmount: 2}]}`
 - Algo transfers (pay transactions)
-  - Amount transferred (min and/or max) e.g. `filter: { type: TransactionType.pay, minAmount: 1, maxAmount: 100 }`
+  - Amount transferred (min and/or max) e.g. `filter: { type: TransactionType.Payment, minAmount: 1, maxAmount: 100 }`
   - Balance changes (sender, receiver, close to, min and/or max change) e.g. `filter: { balanceChanges: [{role: [BalanceChangeRole.Sender], address: "ABC...", minAmount: 1, maxAmount: 2}]}`
 
 You can supply multiple, named filters via the [`NamedTransactionFilter`](../../guide/subscriptions/#namedtransactionfilter) type. When subscribed transactions are returned each transaction will have a `filtersMatched` property that will have an array of any filter(s) that caused that transaction to be returned. When using [`AlgorandSubscriber`](../../guide/subscriber/), you can subscribe to events that are emitted with the filter name.

--- a/docs/src/content/docs/guide/subscriber.md
+++ b/docs/src/content/docs/guide/subscriber.md
@@ -53,13 +53,13 @@ export interface CoreTransactionSubscriptionParams {
    *  filter: [{
    *   name: 'asset-transfers',
    *   filter: {
-   *     type: TransactionType.axfer,
+   *     type: TransactionType.AssetTransfer,
    *     //...
    *   }
    *  }, {
    *   name: 'payments',
    *   filter: {
-   *     type: TransactionType.pay,
+   *     type: TransactionType.Payment,
    *     //...
    *   }
    *  }]

--- a/docs/src/content/docs/guide/subscriptions.md
+++ b/docs/src/content/docs/guide/subscriptions.md
@@ -43,13 +43,13 @@ export interface TransactionSubscriptionParams {
    *  filter: [{
    *   name: 'asset-transfers',
    *   filter: {
-   *     type: TransactionType.axfer,
+   *     type: TransactionType.AssetTransfer,
    *     //...
    *   }
    *  }, {
    *   name: 'payments',
    *   filter: {
-   *     type: TransactionType.pay,
+   *     type: TransactionType.Payment,
    *     //...
    *   }
    *  }]
@@ -177,7 +177,7 @@ Each filter you provide within this type will apply an AND logic between the spe
 
 ```typescript
 filter: {
-  type: TransactionType.axfer,
+  type: TransactionType.AssetTransfer,
   sender: "ABC..."
 }
 ```
@@ -450,7 +450,7 @@ const subscription = await getSubscribedTransactions(
       {
         name: 'filter1',
         filter: {
-          type: TransactionType.acfg,
+          type: TransactionType.AssetConfig,
           sender: 'ER7AMZRPD5KDVFWTUUVOADSOWM4RQKEEV2EDYRVSA757UHXOIEKGMBQIVU',
           assetCreate: true,
         },

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,7 +51,7 @@ const subscriber = new AlgorandSubscriber(
       {
         name: 'filter1',
         filter: {
-          type: TransactionType.pay,
+          type: TransactionType.Payment,
           sender: 'ABC...',
         },
       },

--- a/docs/src/content/docs/migration/v4-migration.md
+++ b/docs/src/content/docs/migration/v4-migration.md
@@ -66,12 +66,12 @@ const subscriber = new AlgorandSubscriber(
 import { TransactionType } from '@algorandfoundation/algokit-utils/transact'
 import type { ApplicationOnComplete } from '@algorandfoundation/algokit-utils/indexer'
 
-// Using in filters (same as before)
+// Using in filters (member names are now PascalCase)
 const subscriber = new AlgorandSubscriber(
   {
     filters: [{
       name: 'payments',
-      filter: { type: TransactionType.pay }
+      filter: { type: TransactionType.Payment }
     }],
     // ...
   },
@@ -150,7 +150,7 @@ const subscriber = new AlgorandSubscriber(
     filters: [{
       name: 'usdc-transfers',
       filter: {
-        type: TransactionType.axfer,
+        type: TransactionType.AssetTransfer,
         assetId: 31566704n,
         minAmount: 1_000_000n,
       }

--- a/docs/src/content/docs/tutorials/quick-start.md
+++ b/docs/src/content/docs/tutorials/quick-start.md
@@ -27,7 +27,7 @@ const subscriber = new AlgorandSubscriber(
       {
         name: 'filter1',
         filter: {
-          type: TransactionType.pay,
+          type: TransactionType.Payment,
           sender: 'ABC...',
         },
       },

--- a/examples/subscriber/04-asset-transfer.ts
+++ b/examples/subscriber/04-asset-transfer.ts
@@ -10,6 +10,7 @@
  * - LocalNet running (via `algokit localnet start`)
  */
 import { algo, AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { TransactionType } from '@algorandfoundation/algokit-utils/transact'
 import { printHeader, printStep, printInfo, printSuccess, printError, shortenAddress, createFilterTester } from './shared/utils.js'
 
 async function main() {
@@ -83,7 +84,7 @@ async function main() {
   // Step 7: Subscribe with type=axfer + assetId filter — matches opt-in and transfer
   printStep(7, 'Filter: type = axfer, assetId = created asset')
   const axferTxns = await testFilter(
-    'asset-transfers', { type: 'axfer', assetId: assetId }, 2,
+    'asset-transfers', { type: TransactionType.AssetTransfer, assetId: assetId }, 2,
     'axfer filter matched 2 transactions (opt-in + transfer)',
     (txn) => {
       const axfer = txn.assetTransferTransaction!

--- a/examples/subscriber/05-app-call.ts
+++ b/examples/subscriber/05-app-call.ts
@@ -14,6 +14,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { algo, AlgorandClient, AppFactory } from '@algorandfoundation/algokit-utils'
+import { ApplicationOnComplete } from '@algorandfoundation/algokit-utils/indexer'
 import { printHeader, printStep, printInfo, printSuccess, printError, shortenAddress, createFilterTester } from './shared/utils.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -119,7 +120,7 @@ async function main() {
   // Step 7: Subscribe with appOnComplete filter — matches by on-complete type
   printStep(7, 'Filter: appOnComplete = optin')
   const optInTxns = await testFilter(
-    'optin-calls', { appOnComplete: 'optin' }, 1,
+    'optin-calls', { appOnComplete: ApplicationOnComplete.optin }, 1,
     'appOnComplete filter matched 1 opt-in transaction',
     (txn) => {
       const appTxn = txn.applicationTransaction

--- a/examples/subscriber/package-lock.json
+++ b/examples/subscriber/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@algorandfoundation/algokit-subscriber": "file:../../dist",
-        "@algorandfoundation/algokit-utils": "^10.0.0-beta.2"
+        "@algorandfoundation/algokit-utils": "^10.0.0-beta.3"
       },
       "devDependencies": {
         "tsx": "^4.21.0",
@@ -27,10 +27,10 @@
         "js-sha512": "^0.9.0"
       },
       "engines": {
-        "node": ">=24.0"
+        "node": ">=22.0"
       },
       "peerDependencies": {
-        "@algorandfoundation/algokit-utils": "^10.0.0-beta.1"
+        "@algorandfoundation/algokit-utils": "^10.0.0-beta.3"
       }
     },
     "node_modules/@algorandfoundation/algokit-subscriber": {
@@ -38,9 +38,9 @@
       "link": true
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "10.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-beta.2.tgz",
-      "integrity": "sha512-V1aYu6Xuj3mxbRVmzkYgDvbObs3BgZVBrp3r5Ro4Pf0GyTOQmZU8DZ2ZH/ye8hREZk5eGeSyVDkj6bVbR4SQxQ==",
+      "version": "10.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-beta.3.tgz",
+      "integrity": "sha512-o3pZ3ES4TxZTym7W1/U6JtKOvJTq9H6tNjlar6bnRNctAmR9v+PCx81HFcP+Nvl5CuNDSMou5sbRnVVNIkWSMA==",
       "license": "MIT",
       "dependencies": {
         "@algorandfoundation/xhd-wallet-api": "2.0.0-canary.1",
@@ -56,7 +56,7 @@
         "vlq": "^2.0.4"
       },
       "engines": {
-        "node": ">=24.0"
+        "node": ">=22.0"
       }
     },
     "node_modules/@algorandfoundation/xhd-wallet-api": {

--- a/examples/subscriber/package.json
+++ b/examples/subscriber/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@algorandfoundation/algokit-subscriber": "file:../../dist",
-    "@algorandfoundation/algokit-utils": "^10.0.0-beta.2"
+    "@algorandfoundation/algokit-utils": "^10.0.0-beta.3"
   },
   "devDependencies": {
     "tsx": "^4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "node": ">=22.0"
       },
       "peerDependencies": {
-        "@algorandfoundation/algokit-utils": "^10.0.0-beta.2"
+        "@algorandfoundation/algokit-utils": "^10.0.0-beta.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -95,9 +95,9 @@
       "license": "MIT"
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "10.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-beta.2.tgz",
-      "integrity": "sha512-V1aYu6Xuj3mxbRVmzkYgDvbObs3BgZVBrp3r5Ro4Pf0GyTOQmZU8DZ2ZH/ye8hREZk5eGeSyVDkj6bVbR4SQxQ==",
+      "version": "10.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-beta.3.tgz",
+      "integrity": "sha512-o3pZ3ES4TxZTym7W1/U6JtKOvJTq9H6tNjlar6bnRNctAmR9v+PCx81HFcP+Nvl5CuNDSMou5sbRnVVNIkWSMA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -114,7 +114,7 @@
         "vlq": "^2.0.4"
       },
       "engines": {
-        "node": ">=24.0"
+        "node": ">=22.0"
       }
     },
     "node_modules/@algorandfoundation/xhd-wallet-api": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "js-sha512": "^0.9.0"
   },
   "peerDependencies": {
-    "@algorandfoundation/algokit-utils": "^10.0.0-beta.2"
+    "@algorandfoundation/algokit-utils": "^10.0.0-beta.3"
   },
   "publishConfig": {
     "access": "public"
@@ -124,10 +124,6 @@
       {
         "name": "main",
         "prerelease": "beta"
-      },
-      {
-        "name": "alpha",
-        "prerelease": "alpha"
       },
       {
         "name": "release"

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -223,13 +223,13 @@ export interface CoreTransactionSubscriptionParams {
    *  filter: [{
    *   name: 'asset-transfers',
    *   filter: {
-   *     type: TransactionType.axfer,
+   *     type: TransactionType.AssetTransfer,
    *     //...
    *   }
    *  }, {
    *   name: 'payments',
    *   filter: {
-   *     type: TransactionType.pay,
+   *     type: TransactionType.Payment,
    *     //...
    *   }
    *  }]


### PR DESCRIPTION
## Summary

This PR makes a few related CI/CD changes:

1. **Hardens the CI workflows** by pinning all third-party GitHub Actions to immutable commit SHAs and tightening workflow permissions to least-privilege.
2. **Removes leftover branch references** (the retired `alpha` prerelease channel and a temporary CI branch trigger) across CI triggers, release config, and the DevPortal workflow.
3. **Keeps the DevPortal docs current** by publishing the rolling `docs-latest` build on every push to `main`.
4. **Bumps `@algorandfoundation/algokit-utils` to `10.0.0-beta.3`** and aligns example and documentation code with its PascalCase `TransactionType` / `ApplicationOnComplete` enums.

## Changes

### CI security hardening

- Pin all third-party actions to full commit SHAs (with `# vX` comments) instead of mutable tags in `pr.yml`, `prod_release.yml`, `publish-devportal-docs.yml`, and `release.yml`. First-party `algokit-shared-config` reusable workflows stay on `@main` per policy.
- Bump `pnpm/action-setup` from v4 to v6 (pinned to its SHA); the pnpm version is still resolved from `docs/package.json`'s `packageManager` field (`pnpm@10.30.3`).
- Narrow top-level `permissions` in `release.yml` from `contents: write` / `issues: read` / `id-token: write` down to `contents: read`, and in `prod_release.yml` from `contents: write` to `contents: read` (jobs that need more grant it locally).
- Simplify the `publish_docs` job in `release.yml` to depend on `release` only (instead of `check_docs`).

### Branch cleanup

- Remove the `alpha` prerelease channel from PR trigger branches (`pr.yml`), release push branches (`release.yml`), and the semantic-release config in `package.json`.
- Update `publish-devportal-docs.yml`: drop the temporary `ci/add-publish-to-devportal-workflow` push trigger and point the publish action at `release/ak-v4`.

### DevPortal docs publishing

- Add a `push: branches: [main]` trigger to `publish-devportal-docs.yml` so the rolling `docs-latest` pre-release is refreshed on every merge to `main`. Tag pushes (`v*`) continue to attach `devportal-docs.tar.gz` to the corresponding version release.

### Dependency bump

- Update `@algorandfoundation/algokit-utils` from `^10.0.0-beta.2` to `^10.0.0-beta.3` in the peer dependency (`package.json`) and the `examples/subscriber` dependency, refreshing both lockfiles.
- Fix two example files that passed raw string literals where algokit-utils v10 expects enums: `04-asset-transfer.ts` now uses `TransactionType.AssetTransfer` (was `'axfer'`) and `05-app-call.ts` uses `ApplicationOnComplete.optin` (was `'optin'`).
- Align `TransactionType` member names to the v10 PascalCase naming (`.Payment` / `.AssetConfig` / `.AssetTransfer`) in `README.md`, `index.mdx`, `guide/`, `concepts/filtering.md`, `tutorials/quick-start.md`, and the `src/types/subscription.ts` JSDoc. Migration guides keep the lowercase algosdk names in their "before" snippets; only the v4 "after" snippets are updated. The v2-to-v3 guide is left untouched (algosdk throughout).

## Why

- Pinning actions to SHAs protects the supply chain against tag-retargeting attacks.
- Least-privilege permissions reduce the blast radius if a workflow or dependency is compromised.
- The `alpha` prerelease channel is being retired, so its triggers and release config are removed to stop further `*-alpha.*` publishes and CI runs on that branch.
- The DevPortal imports each library's "Latest" docs from the `docs-latest` release, which is only refreshed by non-tag runs. Without a `main` trigger, `docs-latest` would go stale and the portal would keep serving outdated docs.
- algokit-utils v10 ships its own PascalCase `TransactionType` / `ApplicationOnComplete` enums (decoupled from algosdk's lowercase ones). The string values are unchanged (`AssetTransfer === 'axfer'`), so the example fixes are type-only with identical runtime behavior; they correct a latent type error that runtime-only example verification never surfaced.
